### PR TITLE
Rename stream to `data_service.all_events`

### DIFF
--- a/v2/asyncapi.yaml
+++ b/v2/asyncapi.yaml
@@ -8,7 +8,7 @@ servers:
     protocol: redis
     description: Renku Redis Instance
 channels:
-  search.sync:
+  data_service.all_events:
     messages:
       syncEvent:
         payload:


### PR DESCRIPTION
The stream is not only for search, rename it according to the producer. See comments in https://github.com/SwissDataScienceCenter/renku-data-services/pull/377/files/acba8f289afa1023a54c40d6836139e44a964c98#r1743224983